### PR TITLE
Cleanup and standardize release

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -34,18 +34,3 @@ jobs:
         OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
         GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
-
-    - name: Get package version
-      run: |
-        git config --global user.email "${ACTOR_EMAIL}"
-        git config --global user.name "${ACTOR_NAME}"
-        PKG_VER=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
-        echo "VER=$PKG_VER"
-        git tag -d "$PKG_VER" || true
-        git push origin --delete "$PKG_VER" || true
-        git tag -a -m "auto-created by CI" "$PKG_VER"
-        git push origin --tags
-      env:
-        ACTOR_NAME: ${{ github.event.pusher.name }}
-        ACTOR_EMAIL: ${{ github.event.pusher.email }}
-        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build-github-package.yml
+++ b/.github/workflows/build-github-package.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: get env data
         run: |
+          echo "********************** STANDARD ENV VARIABLES ********************"
+          env
+          echo ""
+          echo "********************** GITHUB EVENT json *************************"
           echo "${GITHUB_CONTEXT}" | jq '.'
           false
         env:

--- a/.github/workflows/build-github-package.yml
+++ b/.github/workflows/build-github-package.yml
@@ -12,20 +12,25 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        server-id: github
-        settings-path: ${{ github.workspace }} 
-
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
-
-    - name: Publish maven package to GitHub Packages
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
-      env:
-        # GITHUB_TOKEN: ${{ github.token }}
-       GITHUB_TOKEN: ${{ secrets.PKG_PUSH_TOKEN }}
+      - name: get env data
+        run: |
+          echo "${{ github.event }} | jq '.'"
+          false
+          
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }} 
+  
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+  
+      - name: Publish maven package to GitHub Packages
+        run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+        env:
+          # GITHUB_TOKEN: ${{ github.token }}
+         GITHUB_TOKEN: ${{ secrets.PKG_PUSH_TOKEN }}

--- a/.github/workflows/build-github-package.yml
+++ b/.github/workflows/build-github-package.yml
@@ -12,6 +12,10 @@ jobs:
       packages: write
 
     steps:
+      - name: disable workflow
+        run: |
+          false
+
       - name: get env data
         run: |
           echo "********************** STANDARD ENV VARIABLES ********************"

--- a/.github/workflows/build-github-package.yml
+++ b/.github/workflows/build-github-package.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - name: get env data
         run: |
-          echo "${{ github.event }} | jq '.'"
+          echo "${GH_EVENT}" | jq '.'
           false
+        env:
+          GH_EVENT: ${{ github.event }}
           
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/build-github-package.yml
+++ b/.github/workflows/build-github-package.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: get env data
         run: |
-          echo "${GH_EVENT}" | jq '.'
+          echo "${GITHUB_CONTEXT}" | jq '.'
           false
         env:
-          GH_EVENT: ${{ github.event }}
+          GITHUB_CONTEXT: ${{ toJson(github) }}
           
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,17 @@ jobs:
 
     - name: Build and Release to Maven central
       run: |
+        git config --global user.email "${{ github.event.pusher.email }}"
+        git config --global user.name "${{ github.event.pusher.name }}"
         mvn -Prelease --batch-mode clean release:prepare release:perform
       env:
         OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
         GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+        GH_TOKEN: ${{ github.token }}
+
+    - if: cancelled() || failure()
+      run: |
+        mvn --batch-mode release:rollback
+      env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,10 @@
 name: Release to maven central
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
 
 jobs:
-  build:
+  release:
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
 
     - name: Build and Release to Maven central
       run: |
-        git config --global user.email "${{ github.event.pusher.email }}"
-        git config --global user.name "${{ github.event.pusher.name }}"
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
         mvn -Prelease --batch-mode clean release:prepare release:perform
       env:
         OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:
@@ -33,13 +33,11 @@ jobs:
         gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
         gpg-passphrase: GPG_PASSPHRASE
 
-    - if: github.event.release
-      name: Update version in pom.xml (Release only)
-      run: mvn -B versions:set -DnewVersion=${{ github.event.release.tag_name }} -DgenerateBackupPoms=false
-
     - name: Build and Release to Maven central
-      run: mvn -Prelease --batch-mode clean deploy
+      run: |
+        mvn -Prelease --batch-mode clean release:prepare release:perform
       env:
         OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
         GPG_PASSPHRASE: ${{ secrets.ORG_GPG_PASSPHRASE }}
+        GH_TOKEN: ${{ github.token }}

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.eclipse.uprotocol</groupId>
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -24,7 +22,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/shaishap/uprotocol-core-api.git</url>
-        <tag>HEAD</tag>
+        <tag>uprotocol-core-api-1.4.2</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -21,8 +21,8 @@
     <scm>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>https://shaishap@github.com/shaishap/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.2</tag>
+        <url>https://github.com/shaishap/uprotocol-core-api.git</url>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.3</version>
+    <version>1.4.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -22,7 +22,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/shaishap/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.2</version>
+    <version>1.4.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -16,15 +16,13 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scm-user>${env.USER}</scm-user>
     </properties>
 
     <scm>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>https://github.com/shaishap/uprotocol-core-api.git</url>
+        <url>https://shaishap@github.com/shaishap/uprotocol-core-api.git</url>
         <tag>uprotocol-core-api-1.4.2</tag>
-        <username>${scm-user}</username>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <scm-user>${env.USER}</scm-user>
     </properties>
 
     <scm>
@@ -23,6 +24,7 @@
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/shaishap/uprotocol-core-api.git</url>
         <tag>uprotocol-core-api-1.4.2</tag>
+        <username>${scm-user}</username>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -21,7 +21,7 @@
     <scm>
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
-        <url>https://github.com/shaishap/uprotocol-core-api.git</url>
+        <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -22,7 +22,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/shaishap/uprotocol-core-api.git</url>
-        <tag>HEAD</tag>
+        <tag>uprotocol-core-api-1.4.3</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+        <url>https://github.com/shaishap/uprotocol-core-api.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <build>
         <extensions>
             <extension>


### PR DESCRIPTION
* Release is done using the release workflow (and not through github tag > new release)
(Only formal releases will be tagged in the repo)

* Change to maven-release-plugin instead of deploy target
* Version numbering increase done by scm plugin
* Version rollback in case of failed or cancelled release