### PR TITLE
Fix github tag not removed on rollback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,11 @@
                             <passphraseServerId>gpg.passphrase</passphraseServerId>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-release-plugin</artifactId>
+                        <version>3.0.0-M1</version>
+                    </plugin>
                 </plugins>
             </build>
        </profile>


### PR DESCRIPTION
Using maven-release-plugin 3.0.0-M1 which removes github tag as well.