### PR TITLE
Added staging distributionManagement repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,10 @@
         <id>ossrh</id>
         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       </snapshotRepository>
+      <repository>
+       <id>ossrh</id>
+       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      </repository>
     </distributionManagement>
          
     <dependencyManagement>


### PR DESCRIPTION
Release deployments did not reach the oss sonatype central repo.
Adding repository as described in example ref by eclipse support.