### PR TITLE
Remove direct repo promote target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
 
     - name: Release to Maven central
       run: |
-        mvn -B clean release:prepare release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
+        mvn -B clean release:prepare release:perform
+        # mvn -B clean release:prepare release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
         # mvn -B clean release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
       env:
         OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}


### PR DESCRIPTION
This is a redundant options added for debug. release:perform covers it.