### PR TITLE
Release to maven central fixed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,7 +3,7 @@ name: Verify PR
 on:
   pull_request:
     branches:
-      - main
+      - '*'
 
 jobs:
   verify-pr:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -3,8 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - main
-      - stage_nexus
+      - '*'
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - stage_nexus
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,7 @@ jobs:
 
     - name: Stage to Nexus and Release to Maven central
       run: |
-        mvn -B versions:set -DnewVersion=1.4.26
-        mvn -B clean deploy -P release
-        #1 mvn -B release:clean release:prepare -P release release:perform
-        # mvn -B clean release:prepare release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
-        # mvn -B clean release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
+        mvn -B release:clean release:prepare -P release release:perform
       env:
         OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}
@@ -47,8 +43,7 @@ jobs:
 
     - if: cancelled() || failure()
       run: |
-        mvn -B nexus-staging:drop
-        # mvn -B release:rollback nexus-staging:drop
+        mvn -B release:rollback
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Stage to Nexus and Release to Maven central
       run: |
-        mvn -B clean release:prepare -P release deploy release:perform
+        mvn -B release:clean release:prepare -P release release:perform
         # mvn -B clean release:prepare release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
         # mvn -B clean release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
 
     - name: Stage to Nexus and Release to Maven central
       run: |
-        mvn -B clean -P release deploy nexus-staging:release
+        mvn -B versions:set -DnewVersion=1.4.26
+        mvn -B clean deploy -P release
         #1 mvn -B release:clean release:prepare -P release release:perform
         # mvn -B clean release:prepare release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
         # mvn -B clean release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Stage to Nexus and Release to Maven central
       run: |
-        mvn -B clean release:prepare -P release deploy
+        mvn -B clean release:prepare -P release deploy release:perform
         # mvn -B clean release:prepare release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
         # mvn -B clean release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
     - if: cancelled() || failure()
       run: |
-        mvn -B nexus-staging:drop release:rollback
+        mvn -B release:rollback nexus-staging:drop
       env:
         GH_TOKEN: ${{ github.token }}
         GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
 
     - name: Stage to Nexus and Release to Maven central
       run: |
-        mvn -B release:clean release:prepare -P release release:perform
+        mvn -B clean -P release deploy nexus-staging:release
+        #1 mvn -B release:clean release:prepare -P release release:perform
         # mvn -B clean release:prepare release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
         # mvn -B clean release:perform nexus-staging:promote -DstagingRepositoryId=ossrh -DbuildPromotionProfileId=ossrh
       env:
@@ -45,7 +46,8 @@ jobs:
 
     - if: cancelled() || failure()
       run: |
-        mvn -B release:rollback nexus-staging:drop
+        mvn -B nexus-staging:drop
+        # mvn -B release:rollback nexus-staging:drop
       env:
         GH_TOKEN: ${{ github.token }}
         GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.29</version>
+    <version>1.4.30-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -43,7 +43,7 @@
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
 <!--         <tag>uprotocol-core-api-1.4.23</tag> -->
-      <tag>uprotocol-core-api-1.4.29</tag>
+      <tag>HEAD</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.23-SNAPSHOT</version>
+    <version>1.4.23</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.5</version>
+    <version>1.4.6-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.5</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.23</version>
+    <version>1.4.24-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.26-SNAPSHOT</version>
+    <version>1.4.27-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -83,6 +83,7 @@
                  <serverId>ossrh</serverId>
                  <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                  <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                 <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
                </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.27-SNAPSHOT</version>
+    <version>1.4.26-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.26</version>
+    <version>1.4.27-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.26</tag>
+        <tag>uprotocol-core-api-1.4.23</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,9 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>
                 <configuration>
-                <releaseProfiles>release</releaseProfiles>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
                 </configuration>
             </plugin>
             

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.25</version>
+    <version>1.4.26</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.23-SNAPSHOT</version>
+    <version>1.4.23</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>HEAD</tag>
+        <tag>uprotocol-core-api-1.4.23</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.26</version>
+    <version>1.4.26-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.26-SNAPSHOT</version>
+    <version>1.4.25-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.25-SNAPSHOT</version>
+    <version>1.4.24-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.28</version>
+    <version>1.4.29-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.28</tag>
+        <tag>uprotocol-core-api-1.4.23</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.28-SNAPSHOT</version>
+    <version>1.4.27-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.24-SNAPSHOT</version>
+    <version>1.4.24</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.23</tag>
+        <tag>uprotocol-core-api-1.4.24</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 
             <!-- requirement plugins -->
 
-<!--             <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>
@@ -97,7 +97,7 @@
                     <releaseProfiles>release</releaseProfiles>
                     <goals>deploy nexus-staging:release</goals>
                 </configuration>
-            </plugin> -->
+            </plugin>
             
         </plugins>
     </build>
@@ -171,10 +171,10 @@
         <id>ossrh</id>
         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       </snapshotRepository>
-<!--       <repository>
+      <repository>
        <id>ossrh</id>
        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      </repository> -->
+      </repository>
     </distributionManagement>
 
     

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.28-SNAPSHOT</version>
+    <version>1.4.29-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -96,7 +96,8 @@
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
-                    <goals>deploy nexus-staging:release</goals>
+<!--                     <goals>deploy nexus-staging:release</goals> -->
+                    <goals>deploy</goals>
                 </configuration>
             </plugin>
             

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.24</version>
+    <version>1.4.25-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.24</tag>
+        <tag>uprotocol-core-api-1.4.23</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.23</version>
+    <version>1.4.23-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-<!--         <tag>uprotocol-core-api-1.4.23</tag> -->
       <tag>HEAD</tag>
   </scm>
 
@@ -97,7 +96,6 @@
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
-<!--                     <goals>deploy nexus-staging:release</goals> -->
                     <goals>deploy</goals>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.25-SNAPSHOT</version>
+    <version>1.4.25</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -88,7 +88,7 @@
 
             <!-- requirement plugins -->
 
-            <plugin>
+<!--             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>
@@ -97,7 +97,7 @@
                     <releaseProfiles>release</releaseProfiles>
                     <goals>deploy nexus-staging:release</goals>
                 </configuration>
-            </plugin>
+            </plugin> -->
             
         </plugins>
     </build>
@@ -171,10 +171,10 @@
         <id>ossrh</id>
         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       </snapshotRepository>
-      <repository>
+<!--       <repository>
        <id>ossrh</id>
        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      </repository>
+      </repository> -->
     </distributionManagement>
 
     

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.27-SNAPSHOT</version>
+    <version>1.4.28-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -77,7 +77,7 @@
             <plugin>
                <groupId>org.sonatype.plugins</groupId>
                <artifactId>nexus-staging-maven-plugin</artifactId>
-               <version>1.6.7</version>
+               <version>1.6.9</version>
                <extensions>true</extensions>
                <configuration>
                  <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.26-SNAPSHOT</version>
+    <version>1.4.26</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.23</tag>
+        <tag>uprotocol-core-api-1.4.26</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.24-SNAPSHOT</version>
+    <version>1.4.23-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -74,7 +74,7 @@
                 </configuration>
             </plugin>                 
 
-<!--             <plugin>
+            <plugin>
                <groupId>org.sonatype.plugins</groupId>
                <artifactId>nexus-staging-maven-plugin</artifactId>
                <version>1.6.7</version>
@@ -85,7 +85,7 @@
                  <autoReleaseAfterClose>true</autoReleaseAfterClose>
                </configuration>
             </plugin>
- -->
+
             <!-- requirement plugins -->
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.27</version>
+    <version>1.4.28-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.27</tag>
+        <tag>uprotocol-core-api-1.4.23</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.29-SNAPSHOT</version>
+    <version>1.4.28-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -43,8 +43,7 @@
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
 <!--         <tag>uprotocol-core-api-1.4.23</tag> -->
-      <tag>HEAD</tag>
-  </scm>
+    </scm>
 
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.27-SNAPSHOT</version>
+    <version>1.4.27</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.23</tag>
+        <tag>uprotocol-core-api-1.4.27</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.6-SNAPSHOT</version>
+    <version>1.4.23-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.28-SNAPSHOT</version>
+    <version>1.4.28</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -43,7 +43,8 @@
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
 <!--         <tag>uprotocol-core-api-1.4.23</tag> -->
-    </scm>
+      <tag>uprotocol-core-api-1.4.28</tag>
+  </scm>
 
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.29-SNAPSHOT</version>
+    <version>1.4.29</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -43,7 +43,8 @@
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
 <!--         <tag>uprotocol-core-api-1.4.23</tag> -->
-    </scm>
+      <tag>uprotocol-core-api-1.4.29</tag>
+  </scm>
 
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.28-SNAPSHOT</version>
+    <version>1.4.28</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.23</tag>
+        <tag>uprotocol-core-api-1.4.28</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.29-SNAPSHOT</version>
+    <version>1.4.28-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
                 </configuration>
             </plugin>                 
 
-            <plugin>
+<!--             <plugin>
                <groupId>org.sonatype.plugins</groupId>
                <artifactId>nexus-staging-maven-plugin</artifactId>
                <version>1.6.7</version>
@@ -85,17 +85,17 @@
                  <autoReleaseAfterClose>true</autoReleaseAfterClose>
                </configuration>
             </plugin>
-
+ -->
             <!-- requirement plugins -->
 
-<!--             <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>3.0.1</version>
                 <configuration>
                 <releaseProfiles>release</releaseProfiles>
                 </configuration>
-            </plugin> -->
+            </plugin>
             
         </plugins>
     </build>
@@ -169,10 +169,10 @@
         <id>ossrh</id>
         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
       </snapshotRepository>
-<!--       <repository>
+      <repository>
        <id>ossrh</id>
        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      </repository> -->
+      </repository>
     </distributionManagement>
 
     

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.4-SNAPSHOT</version>
+    <version>1.4.4</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>HEAD</tag>
+        <tag>uprotocol-core-api-1.4.4</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.5-SNAPSHOT</version>
+    <version>1.4.5</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>HEAD</tag>
+        <tag>uprotocol-core-api-1.4.5</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.28</version>
+    <version>1.4.29-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -43,7 +43,7 @@
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
 <!--         <tag>uprotocol-core-api-1.4.23</tag> -->
-      <tag>uprotocol-core-api-1.4.28</tag>
+      <tag>HEAD</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.4</version>
+    <version>1.4.5-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.4</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
-                    <goals>deploy</goals>
+                    <goals>deploy nexus-staging:release</goals>
                 </configuration>
             </plugin>
             

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.25-SNAPSHOT</version>
+    <version>1.4.25</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.23</tag>
+        <tag>uprotocol-core-api-1.4.25</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.23</tag>
+<!--         <tag>uprotocol-core-api-1.4.23</tag> -->
     </scm>
 
 
@@ -77,7 +77,7 @@
             <plugin>
                <groupId>org.sonatype.plugins</groupId>
                <artifactId>nexus-staging-maven-plugin</artifactId>
-               <version>1.6.9</version>
+               <version>1.6.13</version>
                <extensions>true</extensions>
                <configuration>
                  <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.23</version>
+    <version>1.4.24-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.23</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.25</version>
+    <version>1.4.26-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 
@@ -42,7 +42,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</url>
-        <tag>uprotocol-core-api-1.4.25</tag>
+        <tag>uprotocol-core-api-1.4.23</tag>
     </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>uprotocol-core-api</artifactId>
     <name>uProtocol Core uEs API</name>
     <description>This project contains the built artifacts for core uProtocol services (uSubscription, uDiscovery, uTwin, etc..). Artifacts include language specific messages and client/server stubs</description>
-    <version>1.4.24-SNAPSHOT</version>
+    <version>1.4.25-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/uprotocol-core-api/</url>
 


### PR DESCRIPTION
after triggering release workflow, packages created and pushed to nexus staging server, and then promoted to maven central. (https://repo1.maven.org/maven2/org/eclipse/uprotocol/uprotocol-core-api/)
The new version will appear in maven central after apx. 10 minutes.

On error promoting, version will be rolled back.