### PR TITLE
Add Missing legal info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * Copyright (c) 2023 General Motors GTO LLC.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-FileType: DOCUMENTATION
+ *
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.uprotocol</groupId>
@@ -125,7 +138,19 @@
                     <goals>deploy</goals>
                 </configuration>
             </plugin>
-            
+                <plugin>
+                    <groupId>org.eclipse.dash</groupId>
+                    <artifactId>license-tool-plugin</artifactId>
+                    <version>1.0.3-SNAPSHOT</version>
+                    <executions>
+                        <execution>
+                            <id>license-check</id>
+                            <goals>
+                                <goal>license-check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
         </plugins>
     </build>
 
@@ -218,7 +243,17 @@
       </repository>
     </distributionManagement>
 
-    
+    <pluginRepositories>
+        <pluginRepository>
+            <id>dash-licenses-snapshots</id>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+
+    </pluginRepositories>
+
     <profiles>
         <profile>
             <id>release</id>
@@ -260,7 +295,8 @@
                             <passphraseServerId>gpg.passphrase</passphraseServerId>
                         </configuration>
                     </plugin>
-                        
+                    
+
                 </plugins>
             </build>
         </profile>

--- a/src/main/proto/core/udiscovery/v3/udiscovery.proto
+++ b/src/main/proto/core/udiscovery/v3/udiscovery.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 syntax = "proto3";
 

--- a/src/main/proto/core/usubscription/v3/usubscription.proto
+++ b/src/main/proto/core/usubscription/v3/usubscription.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 syntax = "proto3";
 

--- a/src/main/proto/core/utwin/v1/utwin.proto
+++ b/src/main/proto/core/utwin/v1/utwin.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 syntax = "proto3";
 

--- a/src/main/proto/file.proto
+++ b/src/main/proto/file.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
  syntax = "proto3";
 

--- a/src/main/proto/options.proto
+++ b/src/main/proto/options.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 syntax = "proto3";
 

--- a/src/main/proto/uattributes.proto
+++ b/src/main/proto/uattributes.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
  syntax = "proto3";
 

--- a/src/main/proto/units.proto
+++ b/src/main/proto/units.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 syntax = "proto3";
 

--- a/src/main/proto/upayload.proto
+++ b/src/main/proto/upayload.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
  syntax = "proto3";
 

--- a/src/main/proto/uri.proto
+++ b/src/main/proto/uri.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
 syntax = "proto3";
 

--- a/src/main/proto/uuid.proto
+++ b/src/main/proto/uuid.proto
@@ -17,6 +17,10 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * SPDX-FileType: SOURCE
+ * SPDX-FileCopyrightText: 2023 General Motors GTO LLC
+ * SPDX-License-Identifier: Apache-2.0
  */
  syntax = "proto3";
 


### PR DESCRIPTION
Adding the missing SPDX tags as well as added in support for Eclipse-Dash that performs dependency checking for the project, we will use this for verify-pr and release targets later

#35