### PR TITLE
Fix dash Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
                 <plugin>
                     <groupId>org.eclipse.dash</groupId>
                     <artifactId>license-tool-plugin</artifactId>
-                    <version>1.0.3-SNAPSHOT</version>
+                    <version>1.0.2</version>
                     <executions>
                         <execution>
                             <id>license-check</id>
@@ -245,11 +245,8 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>dash-licenses-snapshots</id>
-            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
+            <id>dash-licenses-releases</id>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses-releases/</url>
         </pluginRepository>
 
     </pluginRepositories>


### PR DESCRIPTION
Use the released 1.0.2 and not snapshot 1.0.3 otherwise the maven release target will fail.