### PR TITLE
Subscriber info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
                 <plugin>
                     <groupId>org.eclipse.dash</groupId>
                     <artifactId>license-tool-plugin</artifactId>
-                    <version>1.0.3-SNAPSHOT</version>
+                    <version>1.0.2</version>
                     <executions>
                         <execution>
                             <id>license-check</id>
@@ -245,11 +245,8 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>dash-licenses-snapshots</id>
-            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
+            <id>dash-licenses-releases</id>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses-releases/</url>
         </pluginRepository>
 
     </pluginRepositories>

--- a/src/main/proto/core/udiscovery/v3/udiscovery.proto
+++ b/src/main/proto/core/udiscovery/v3/udiscovery.proto
@@ -105,7 +105,7 @@ service uDiscovery {
 
 
   // Register to receive Notifications to changes to one of more Nodes. The changes
-  // are published on the notification topic: '/core.udiscovery/3/nodes#Update'
+  // are published on the notification topic: '/core.udiscovery/3/nodes#Notification'
   rpc RegisterForNotifications(NotificationsRequest) returns (google.rpc.Status) {
     option (method_id) = 8;
   }

--- a/src/main/proto/core/usubscription/v3/usubscription.proto
+++ b/src/main/proto/core/usubscription/v3/usubscription.proto
@@ -124,8 +124,9 @@ message SubscribeAttributes {
 
 // Subscriber Identification Information
 message SubscriberInfo {
-  // Fully qualified uProtocol subscriber URI, ex. `up://device.domain/com.gm.app.hartley`
-  string uri = 1;
+  // subscriber URI containig the names and numbers of the 
+  // uE subscribing. Example represented in long form: `//device.domain/com.gm.app.hartley`
+  v1.UUri uri = 1;
 
   // Any additional device specific subscriber information
   repeated google.protobuf.Any details = 2;


### PR DESCRIPTION
Need Subscriber info to pass names and numbers so that the device dispatchers can do efficient routing over transports that use only names or only numbers. 
#59 