### PR TITLE
Fix SubscriberInfo and documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,10 +4,28 @@ image:https://img.shields.io/badge/License-Apache%202.0-blue.svg[License,link=ht
 
 *NOTE:* _Please refer to https://github.com/eclipse-uprotocol/uprotocol-spec[] for more information about uProtocol_
 
+== Overview
 
-== How To Build?
+This project contains the core data models (UUri, UAttributes, etc..) and core services definitions (uDiscovery, uSubscription, uTwin) of uProtocol. This project is used by other uprotocol projects such as the language specific SDKs and uLink library that extend the data model to add validators, serializers, and factory/builder methods.
 
-This project builds the core services (uSubscription, uDiscovery, uTwin) using the maven build system. Import the project into your favorite IDE and select one of the build targets from maven Lifecycle dropdown list.
 
-*NOTE:* _Coming soon the project will pull in the language-specific SDKs to build client-server stubs for the core services. Eventually, the stub generation could be extended to non-uProtocol service definitions (ex. ADAS, charging stations, cloud services, etc...)_
+=== How To Build?
 
+The Project uses maven to build the protobuf message. The target to build the code is:
+
+[source,bash]
+----
+mvn verify -f "pom.xml"
+----
+
+=== How To Use?
+To pull the built (java) artifacts from maven central, add the following dependency to your pom.xml file:
+[source]
+----
+<!-- uProtocol Core -->
+<dependency>
+    <groupId>org.eclipse.uprotocol</groupId>
+    <artifactId>uprotocol-core-api</artifactId>
+    <version>1.5.0</version>
+</dependency>
+----

--- a/src/main/proto/core/udiscovery/v3/udiscovery.proto
+++ b/src/main/proto/core/udiscovery/v3/udiscovery.proto
@@ -105,7 +105,7 @@ service uDiscovery {
 
 
   // Register to receive Notifications to changes to one of more Nodes. The changes
-  // are published on the notification topic: '/core.udiscovery/3/nodes#Update'
+  // are published on the notification topic: '/core.udiscovery/3/nodes#Notification'
   rpc RegisterForNotifications(NotificationsRequest) returns (google.rpc.Status) {
     option (method_id) = 8;
   }

--- a/src/main/proto/core/usubscription/v3/usubscription.proto
+++ b/src/main/proto/core/usubscription/v3/usubscription.proto
@@ -124,8 +124,9 @@ message SubscribeAttributes {
 
 // Subscriber Identification Information
 message SubscriberInfo {
-  // Fully qualified uProtocol subscriber URI, ex. `up://device.domain/com.gm.app.hartley`
-  string uri = 1;
+  // subscriber URI containig the names and numbers of the 
+  // uE subscribing. Example represented in long form: `//device.domain/com.gm.app.hartley`
+  v1.UUri uri = 1;
 
   // Any additional device specific subscriber information
   repeated google.protobuf.Any details = 2;


### PR DESCRIPTION
SubscriberInfo passed URI needs to have the ability to pass names and numbers of the uE & topic/method so that address based dispatchers can properly route the message to the correct destination.

#59