### PR TITLE
uTwin use uMessage (#69)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,14 +183,6 @@
 
     
     <dependencies>
-
-        <!-- https://mvnrepository.com/artifact/io.cloudevents/cloudevents-protobuf -->
-        <dependency>
-            <groupId>io.cloudevents</groupId>
-            <artifactId>cloudevents-protobuf</artifactId>
-            <version>2.2.0</version>
-        </dependency>
-
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>

--- a/src/main/proto/core/utwin/v1/utwin.proto
+++ b/src/main/proto/core/utwin/v1/utwin.proto
@@ -29,7 +29,7 @@ package uprotocol.core.utwin.v1;
 import "google/rpc/status.proto";
 import "uprotocol_options.proto";
 import "uri.proto";
-import "spec.proto"; // CloudEvents proto
+import "umessage.proto";
 
 option java_package = "org.eclipse.uprotocol.core.utwin.v1";
 option java_outer_classname = "UTwinProto";
@@ -51,17 +51,14 @@ service uTwin {
     option (method_id) = 1;
   }
 
-  // A call to SetLastEvent (typically from uBus) sets the uTwin internal cache 
-  // as follows: a pair (topic, event) for future retrieval based on topic as
-  // the primary key to retrieve an event:
-  // - topic is set to CloudEvent.source
-  // - event is set to CloudEvent
+  // A call to SetLastEvent (typically from uBus) to update the uTwin internal cache 
+  // with a message for a given topic (UMessage.source). 
   // Return value status.Code is one of:
-  // - OK if CE was successfully stored in uTwin
-  // - INVALID argument if uTwin encountered an issue with CE content (source field in particular) 
+  // - OK if UMessage was successfully stored in uTwin
+  // - INVALID argument if uTwin encountered an issue with UMessage content (source field in particular) 
   // - PERMISSION_DENIED if requesting uE does not have permission to access the Topic
-  // - RESOURCE_EXHAUSTED if uTwin has no more memory available to store new CEs
-  rpc SetLastEvent(io.cloudevents.v1.CloudEvent) returns (google.rpc.Status) {
+  // - RESOURCE_EXHAUSTED if uTwin has no more memory available to store new UMessages
+  rpc SetLastEvent(uprotocol.v1.UMessage) returns (google.rpc.Status) {
     option (method_id) = 2;
   }
 
@@ -77,7 +74,7 @@ message GetLastEventResponse {
   google.rpc.Status status = 2;
 
   // Event when the topic has been fetched successfully, otherwise empty
-  io.cloudevents.v1.CloudEvent event = 3;
+  uprotocol.v1.UMessage event = 3;
 }
 
 

--- a/src/main/proto/umessage.proto
+++ b/src/main/proto/umessage.proto
@@ -38,8 +38,8 @@
 // It contains a UUri, UAttributes, and UPayload and is a way of representing a 
 // message that would be sent between two uEs.
 message UMessage {
-    // The source (address) of the message. For published events thi sis the producers publish topic
-    // for requests it is the calling uE respose topic (who sent the request). For requests this is the
+    // The source (address) of the message. For published events this is the producers publish topic
+    // for requests it is the calling uE respose topic (who sent the request). For responses this is the
     // method URI from the uService
     UUri source = 1;
 


### PR DESCRIPTION
* uTwin use uMessage

uTwin was locked with the CloudEvent data model that worked for implementations that used CloudEvents however not all transports used them so the following change will replace CloudEvents for UMessage that can be mapped to CloudEvents as needed.

#68

* remove io.cloudevents dependency