### PR TITLE
Support resolved URIs

### DIFF
--- a/uprotocol/uri.proto
+++ b/uprotocol/uri.proto
@@ -54,16 +54,13 @@ message UUri {
 // An Authority represents the deployment location of a specific Software Entity.
 // Authority can be represented in either a name (i.e example.com), ip address (205.236.147.1)
 // or an ID (i.e. VIN, SHA 128, or any other identifier that is less than 255 bytes.
-// *NOTE:* When Authority is empty (neither name, ip, or id is set) the authority
+// *NOTE:* When Authority is empty (neither name, ip, or id are set) the authority
 // is local.
 message UAuthority {
-  // Remote authority information, if not present, authority is local
-  oneof remote {
-    string name = 1;		// domain & device name as a string
-    bytes ip = 2; 			// IPv4 or IPv6 Address in byte format
-    bytes id = 3;			  // Unique ID for the device, could be a VIN, SHA 128, or any other identifier
-                        // *NOTE:* MAX length is 255 bytes
-  }
+  optional string name = 1; // Domain & device name as a string
+  optional bytes ip = 2; 		// IPv4 or IPv6 Address in byte format
+  optional bytes id = 3;		// Unique ID for the device, could be a VIN, SHA 128, or any other identifier
+                            // *NOTE:* MAX length is 255 bytes
 }
 
 


### PR DESCRIPTION
In order to support resolved UAuthority, we need to pass both name and IP and/or ID, otherwise we only have partial and isResolved() for remote URIs will never be true. The change is backwards compatible.

#94